### PR TITLE
check `qname` and `tname` type after `fread`

### DIFF
--- a/R/clean_windows.R
+++ b/R/clean_windows.R
@@ -471,6 +471,7 @@ clean_windows <- function(faFiles,
     sameScale = FALSE,
     braidOffset = .075,
     chrWidth = .05,
+    highlightInversions = highlightInversions,
     ...)
   pl2 <- riparian_paf(
     pafFiles = rawFiles$synFile,
@@ -481,6 +482,7 @@ clean_windows <- function(faFiles,
     sameScale = TRUE,
     braidOffset = .075,
     chrWidth = .05,
+    highlightInversions = highlightInversions,
     ...)
   if(verbose)
     cat(sprintf("\n\t wrote to: riparian_phasedBy%s.pdf", refGenome))

--- a/R/clean_windows.R
+++ b/R/clean_windows.R
@@ -472,6 +472,7 @@ clean_windows <- function(faFiles,
     braidOffset = .075,
     chrWidth = .05,
     highlightInversions = highlightInversions,
+    braidAlpha = braidAlpha,
     ...)
   pl2 <- riparian_paf(
     pafFiles = rawFiles$synFile,
@@ -483,6 +484,7 @@ clean_windows <- function(faFiles,
     braidOffset = .075,
     chrWidth = .05,
     highlightInversions = highlightInversions,
+    braidAlpha = braidAlpha,
     ...)
   if(verbose)
     cat(sprintf("\n\t wrote to: riparian_phasedBy%s.pdf", refGenome))

--- a/R/plot_utils.R
+++ b/R/plot_utils.R
@@ -94,6 +94,8 @@ transform_paf2riparian <- function(paf,
                                    colorColumn = NULL,
                                    chrWidth = braidOffset){
   blks <- data.table(paf)
+  blks[, qname := as.character(qname)]
+  blks[, tname := as.character(tname)]
   plWt <- dev.size()[1]
   plHt <- dev.size()[2]
 

--- a/R/riparian_paf.R
+++ b/R/riparian_paf.R
@@ -130,6 +130,8 @@ riparian_paf <- function(pafFiles,
         fread(rhmd$path[i], col.names = pafNames),
         query = rhmd$query[i],
         target = rhmd$target[i])))
+    refh[, qname := as.character(qname)]
+    refh[, tname := as.character(tname)]
 
     # -- round query hit positions for a fuzzy join
     refh[,rnd := round_toInteger((qstart + qend) / 2, round2join)]
@@ -143,6 +145,8 @@ riparian_paf <- function(pafFiles,
     x <- dcmd[i,]
     # -- read in the daisy chain hits
     pafi <- fread(x$path, col.names = pafNames)
+    pafi[, qname := as.character(qname)]
+    pafi[, tname := as.character(tname)]
 
     if(sameChrOnly)
       pafi <- subset(pafi, tname == qname)


### PR DESCRIPTION
Dear @jtlovell,
I had one issue where the `fasta` file chromsome names are just `integers`. In that case I needed to ensure that `qname` and `tname` are of type `character`.
Best regards
Kristian